### PR TITLE
Support tool installation change

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@ automated conda package building system for the astroconda project.
 
 - `/jenkins` : Jenkins CI pipeline build script(s) ([Groovy](http://www.groovy-lang.org/))
 - `/manifests` : Lists of conda package & metapackage recipes, and associated metadata for various astroconda release types ([YAML](http://yaml.org/))
-
+- `/patches` : Patches to apply to conda machinery immediately after installation of conda to fix bugs that have not yet been corrected in available/applicable releases.

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -124,7 +124,6 @@ node(LABEL) {
         // Get build utilities
         dir(this.utils_dir) {
             git url: UTILS_REPO
-            sh "python setup.py install"
         }
 
         // Check for the availability of a download tool and then use it
@@ -155,7 +154,7 @@ node(LABEL) {
 
         // Install specific versions of miniconda and conda-build
         sh "bash ./${conda_installer} -b -p miniconda"
-        env.PATH = "${env.WORKSPACE}/miniconda/bin/:${env.PATH}"
+        env.PATH = "${env.WORKSPACE}/miniconda/bin:${env.PATH}"
         sh "conda install --quiet conda=${CONDA_VERSION}"
         sh "conda install --quiet --yes conda-build=${CONDA_BUILD_VERSION}"
 
@@ -167,6 +166,8 @@ node(LABEL) {
         def full_patchname = "${patches_dir}/${patchname}"
         sh "patch ${filename} ${full_patchname}"
 
+        // Install support tools
+        sh "python setup.py install"
     }
 
     stage("Generate build list") {

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -167,7 +167,9 @@ node(LABEL) {
         sh "patch ${filename} ${full_patchname}"
 
         // Install support tools
-        sh "python setup.py install"
+        dir(this.utils_dir) {
+            sh "python setup.py install"
+        {
     }
 
     stage("Generate build list") {

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -42,6 +42,10 @@ node(LABEL) {
     }
     assert uname != null
 
+    env.PYTHONPATH = ""
+    // Make the log files a bit more deterministic
+    env.PYTHONUNBUFFERED = "true"
+
     // Delete any existing job workspace directory contents.
     // The directory deleted is the one named after the jenkins pipeline job.
     deleteDir()
@@ -72,12 +76,14 @@ node(LABEL) {
         "OSverion: ${this.OSversion}\n" +
         "script: dispatch.groovy\n" +
         "env.WORKSPACE: ${env.WORKSPACE}\n" +
+        "PATH: ${PATH}\n" +
+        "PYTHONPATH: ${env.PYTHONPATH}\n" +
+        "PYTHONUNBUFFERED: ${env.PYTHONUNBUFFERED}\n" +
         "  Job suite parameters:\n" +
         "LABEL: ${LABEL}\n" +
         "env.NODE_NAME: ${env.NODE_NAME}\n" +
         "PY_VERSION: ${PY_VERSION}\n" +
         "MANIFEST_FILE: ${MANIFEST_FILE}\n" +
-        "PATH: ${PATH}\n" +
         "CONDA_VERSION: ${CONDA_VERSION}\n" +
         "CONDA_BUILD_VERSION: ${CONDA_BUILD_VERSION}\n" +
         "CONDA_BASE_URL: ${CONDA_BASE_URL}\n" +

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -118,6 +118,7 @@ node(LABEL) {
         // Get build utilities
         dir(this.utils_dir) {
             git url: UTILS_REPO
+            sh "python setup.py install"
         }
 
         // Check for the availability of a download tool and then use it
@@ -170,7 +171,7 @@ node(LABEL) {
            culled_option = ""
         }
         def build_list_file = "build_list"
-        cmd = "${this.utils_dir}/rambo.py"
+        cmd = "rambo"
         args = ["--platform ${this.CONDA_PLATFORM}",
                 "--python ${PY_VERSION}",
                 "--manifest manifests/${MANIFEST_FILE}",

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -169,7 +169,7 @@ node(LABEL) {
         // Install support tools
         dir(this.utils_dir) {
             sh "python setup.py install"
-        {
+        }
     }
 
     stage("Generate build list") {

--- a/jenkins/package_builder.groovy
+++ b/jenkins/package_builder.groovy
@@ -3,6 +3,9 @@ node(this.label) {
     dir(this.parent_workspace) {
 
         env.PATH = "${this.parent_workspace}/miniconda/bin/:" + "${env.PATH}"
+        env.PYTHONPATH = ""
+        // Make the log files a bit more deterministic
+        env.PYTHONUNBUFFERED = "true"
         def time = new Date()
 
         println("\n" +
@@ -18,10 +21,9 @@ node(this.label) {
         "env.WORKSPACE: ${env.WORKSPACE}\n" +
         "env.JENKINS_HOME: ${env.JENKINS_HOME}\n" +
         "parameter py_version: ${this.py_version}\n" +
-        "PATH: ${env.PATH}\n")
-
-        // Make the log files a bit more deterministic
-        env.PYTHONUNBUFFERED = "true"
+        "PATH: ${env.PATH}\n" +
+        "PYTHONPATH: ${env.PYTHONPATH}\n" +
+        "PYTHONUNBUFFERED: ${env.PYTHONUNBUFFERED}\n")
 
         // In the directory common to all package build jobs,
         // run conda build --dirty for this package to use any existing work


### PR DESCRIPTION
Use packaged support tool, with an installation step, rather than direct git checkout to accommodate easier standalone use of support tool.

Changed sequence of variable assignments and directory visitations to enable the above.

Minor doc addition