### PR TITLE
Build status propagation to dispatch job

### DIFF
--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -15,6 +15,8 @@
 this.utils_dir = "utils"
 this.recipes_dir = "conda-recipes"
 
+this.build_status_file = "propagated_build_status"
+
 // The conda installer script to use for various <OS><py_version> combinations.
 this.conda_installers  = ["Linux-py2.7":"Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh",
                           "Linux-py3.5":"Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh",
@@ -195,6 +197,10 @@ node(LABEL) {
         this.build_list = build_list_text.trim().tokenize()
         println("Build list:")
         println(build_list_text)
+
+        // Write build status file to facilitate build status propagation
+        // from child jobs.
+        sh "echo SUCCESS > ${this.build_status_file}"
     }
 
     stage("Build packages") {
@@ -210,6 +216,9 @@ node(LABEL) {
                  string(name: "channel_URL", value: this.manifest.channel_URL)],
               propagate: false
         }
+        // Set overall status to that propagated from individual jobs.
+        // This will be the most severe status encountered in all sub jobs.
+        currentBuild.result = readFile this.build_status_file
     }
 }
 

--- a/jenkins/package_builder.groovy
+++ b/jenkins/package_builder.groovy
@@ -1,3 +1,5 @@
+this.build_status_file = "${this.parent_workspace}/propagated_build_status"
+
 node(this.label) {
 
     dir(this.parent_workspace) {
@@ -27,6 +29,8 @@ node(this.label) {
         "PATH: ${env.PATH}\n" +
         "PYTHONPATH: ${env.PYTHONPATH}\n" +
         "PYTHONUNBUFFERED: ${env.PYTHONUNBUFFERED}\n")
+
+        def build_status = readFile this.build_status_file
 
         // In the directory common to all package build jobs,
         // run conda build --dirty for this package to use any existing work
@@ -63,6 +67,11 @@ node(this.label) {
                           returnStatus: true)
                 if (stat != 0) {
                     currentBuild.result = "FAILURE"
+                    // Check if build status file already contains failure
+                    // status. If not, write failure status to the file.
+                    if (build_status != "FAILURE") {
+                        sh "echo FAILURE > ${this.build_status_file}"
+                    }
                 }
             }
 
@@ -79,6 +88,11 @@ node(this.label) {
                           returnStatus: true)
                 if (stat != 0) {
                     currentBuild.result = "UNSTABLE"
+                    // Check if build status file already contains unstable
+                    // status. If not, write unstable status to the file.
+                    if (build_status != "FAILURE") {
+                        sh "echo FAILURE > ${this.build_status_file}"
+                    }
                 }
             }
 


### PR DESCRIPTION
This propagates the most severe build status (SUCCES->UNSTABLE->FAILURE) to the dispatch job so an overall summary can be had via the dispatch job of the collection of child jobs.