### PR TITLE
Patch based on conda-build version

### DIFF
--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -166,7 +166,7 @@ node(LABEL) {
         def conda_build_version = sh(script: "conda-build --version", returnStdout: true)
         def conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
         if (conda_build_maj_ver == "2") {
-            println("conda_build_maj_ver ${conda_build_maj_ver} detected. Applying bugfix patch.")
+            println("conda-build major version ${conda_build_maj_ver} detected. Applying bugfix patch.")
             def filename = "${env.WORKSPACE}/miniconda/lib/python${PY_VERSION}/" +
                            "site-packages/conda_build/config.py"
             def patches_dir = "${env.WORKSPACE}/patches"

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -162,11 +162,11 @@ node(LABEL) {
         def cpkgs = "conda=${CONDA_VERSION} conda-build=${CONDA_BUILD_VERSION}"
         sh "conda install --quiet --yes ${cpkgs} python=${PY_VERSION}"
 
-        // Apply bugfix patch only to conda_build 2.1.1 - 2.1.15 - (?)
+        // Apply bugfix patch only to conda_build 2.x
         def conda_build_version = sh(script: "conda-build --version", returnStdout: true)
         def conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
-        println("conda_build_maj_ver = ${conda_build_maj_ver}")
         if (conda_build_maj_ver == "2") {
+            println("conda_build_maj_ver ${conda_build_maj_ver} detected. Applying bugfix patch.")
             def filename = "${env.WORKSPACE}/miniconda/lib/python${PY_VERSION}/" +
                            "site-packages/conda_build/config.py"
             def patches_dir = "${env.WORKSPACE}/patches"

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -163,10 +163,10 @@ node(LABEL) {
         sh "conda install --quiet --yes ${cpkgs} python=${PY_VERSION}"
 
         // Apply bugfix patch only to conda_build 2.1.1 - 2.1.15 - (?)
-        conda_build_version = sh(script: "conda-build --version", returnStdout: true)
-        conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
+        def conda_build_version = sh(script: "conda-build --version", returnStdout: true)
+        def conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
         println("conda_build_maj_ver = ${conda_build_maj_ver}")
-        if (conda_build_major_ver == "2") {
+        if (conda_build_maj_ver == "2") {
             def filename = "${env.WORKSPACE}/miniconda/lib/python${PY_VERSION}/" +
                            "site-packages/conda_build/config.py"
             def patches_dir = "${env.WORKSPACE}/patches"

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -162,13 +162,18 @@ node(LABEL) {
         def cpkgs = "conda=${CONDA_VERSION} conda-build=${CONDA_BUILD_VERSION}"
         sh "conda install --quiet --yes ${cpkgs} python=${PY_VERSION}"
 
-        // Apply bugfix patch to conda_build 2.1.1 - 2.1.15 - (?)
-        def filename = "${env.WORKSPACE}/miniconda/lib/python${PY_VERSION}/" +
-                       "site-packages/conda_build/config.py"
-        def patches_dir = "${env.WORKSPACE}/patches"
-        def patchname = "conda_build_2.1.1_substr_fix_py${this.py_maj_version}.patch"
-        def full_patchname = "${patches_dir}/${patchname}"
-        sh "patch ${filename} ${full_patchname}"
+        // Apply bugfix patch only to conda_build 2.1.1 - 2.1.15 - (?)
+        conda_build_version = sh(script: "conda-build --version", returnStdout: true)
+        conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
+        println("conda_build_maj_ver = ${conda_build_maj_ver}")
+        if (conda_build_major_ver == "2") {
+            def filename = "${env.WORKSPACE}/miniconda/lib/python${PY_VERSION}/" +
+                           "site-packages/conda_build/config.py"
+            def patches_dir = "${env.WORKSPACE}/patches"
+            def patchname = "conda_build_2.1.1_substr_fix_py${this.py_maj_version}.patch"
+            def full_patchname = "${patches_dir}/${patchname}"
+            sh "patch ${filename} ${full_patchname}"
+        }
 
         // Install support tools
         dir(this.utils_dir) {


### PR DESCRIPTION
Selectively apply bugfix patch when conda-build 2.x is used; conda-build 3.x no longer has the bug.