### PR TITLE
Generalize for python versions

### DIFF
--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -172,6 +172,7 @@ node(LABEL) {
 
         // Apply bugfix patch only to conda_build 2.x
         def conda_build_version = sh(script: "conda-build --version", returnStdout: true)
+        println(" **>> conda_build_version = ${conda_build_version}")
         def conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
         if (conda_build_maj_ver == "2") {
             println("conda-build major version ${conda_build_maj_ver} detected. Applying bugfix patch.")

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -171,7 +171,7 @@ node(LABEL) {
         sh "conda install --quiet --yes ${cpkgs} python=${PY_VERSION}"
 
         // Apply bugfix patch only to conda_build 2.x
-        def conda_build_version = sh(script: "conda-build --version", returnStdout: true).trim()
+        def conda_build_version = sh(script: "conda-build --version 2>&1", returnStdout: true).trim()
         println(" **>> conda_build_version = ${conda_build_version}")
         def conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
         if (conda_build_maj_ver == "2") {

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -171,7 +171,7 @@ node(LABEL) {
         sh "conda install --quiet --yes ${cpkgs} python=${PY_VERSION}"
 
         // Apply bugfix patch only to conda_build 2.x
-        def conda_build_version = sh(script: "conda-build --version", returnStdout: true)
+        def conda_build_version = sh(script: "conda-build --version", returnStdout: true).trim()
         println(" **>> conda_build_version = ${conda_build_version}")
         def conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
         if (conda_build_maj_ver == "2") {

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -262,7 +262,7 @@ node(LABEL) {
                 println("Lockfile already exists, waiting for it to be released...")
                 while ( tries_remaining > 0) {
                     println("Waiting ${this.publication_lock_wait_s}s for lockfile release...")
-                    sleep(this.publication_lock_wait_s * 1000)
+                    sleep(this.publication_lock_wait_s)
                     if ( !file.exists() ) {
                         break
                     }

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -18,10 +18,10 @@ this.recipes_dir = "conda-recipes"
 this.build_status_file = "propagated_build_status"
 
 // The conda installer script to use for various <OS><py_version> combinations.
-this.conda_installers  = ["Linux-py2.7":"Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh",
-                          "Linux-py3.5":"Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh",
-                          "MacOSX-py2.7":"Miniconda2-${CONDA_VERSION}-MacOSX-x86_64.sh",
-                          "MacOSX-py3.5":"Miniconda3-${CONDA_VERSION}-MacOSX-x86_64.sh"]
+this.conda_installers  = ["Linux-py2":"Miniconda2-${CONDA_VERSION}-Linux-x86_64.sh",
+                          "Linux-py3":"Miniconda3-${CONDA_VERSION}-Linux-x86_64.sh",
+                          "MacOSX-py2":"Miniconda2-${CONDA_VERSION}-MacOSX-x86_64.sh",
+                          "MacOSX-py3":"Miniconda3-${CONDA_VERSION}-MacOSX-x86_64.sh"]
 
 // Values controlling the conda index stage which happens after any packages are created.
 this.max_publication_tries = 5
@@ -159,8 +159,10 @@ node(LABEL) {
             sh "false"
         }
 
+        //def conda_installer =
+        //   this.conda_installers["${this.OSname}-py${PY_VERSION}"]
         def conda_installer =
-           this.conda_installers["${this.OSname}-py${PY_VERSION}"]
+           this.conda_installers["${this.OSname}-py${this.py_maj_version}"]
         dl_cmd = dl_cmd + " ${CONDA_BASE_URL}/${conda_installer}"
         sh dl_cmd
 

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -171,8 +171,10 @@ node(LABEL) {
         sh "conda install --quiet --yes ${cpkgs} python=${PY_VERSION}"
 
         // Apply bugfix patch only to conda_build 2.x
+        // py2 conda-build outputs version string to stderr
+        // whereas the py3 version outputs it to stdout. Merge output streams here to capture
+        // all output under both circumstances.
         def conda_build_version = sh(script: "conda-build --version 2>&1", returnStdout: true).trim()
-        println(" **>> conda_build_version = ${conda_build_version}")
         def conda_build_maj_ver = conda_build_version.tokenize()[1].tokenize('.')[0]
         if (conda_build_maj_ver == "2") {
             println("conda-build major version ${conda_build_maj_ver} detected. Applying bugfix patch.")

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -249,7 +249,6 @@ node(LABEL) {
         def artifacts_present =
             sh(script: "ls ${this.conda_build_output_dir}/*.tar.bz2 >/dev/null 2>&1",
                returnStatus: true)
-        println("artifacts present = ${artifacts_present}")
         if (artifacts_present == 0) {
             sh(script: "rsync -avzr ${this.conda_build_output_dir}/*.tar.bz2 ${publication_path}")
             // Use a lock file to prevent two dispatch jobs that finish at the same
@@ -275,6 +274,8 @@ node(LABEL) {
                 }
                 sh(script: "rm -f ${lockfile}")
             }
+        } else {
+            println("No build artifacts found.")
         }
     }
 }


### PR DESCRIPTION
* Generalize miniconda installer choice based on requested python major version.
* Adjust publication lock file retry interval.
* Capture all output from conda-build --version to accommodate difference in behavior between py2 and py3 versions.