### PR TITLE
Properly support master branch tags

### DIFF
--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -64,6 +64,12 @@ node(LABEL) {
 
     // Get the manifest and build control files
     git branch: BUILD_CONTROL_BRANCH, url: BUILD_CONTROL_REPO
+    // If a tag was specified in the job-suite-generator configuration,
+    // explicitly check out that tag after cloning the (master) branch,
+    // since the 'git' pipeline step does not yet support accessing tags.
+    if (BUILD_CONTROL_TAG != "") {
+        sh(script: "git checkout tags/${BUILD_CONTROL_TAG}")
+    }
 
     this.manifest = readYaml file: "manifests/${MANIFEST_FILE}"
     if (this.manifest.channel_URL[-1..-1] == "/") {

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -107,6 +107,7 @@ node(LABEL) {
         "CONDA_BASE_URL: ${CONDA_BASE_URL}\n" +
         "BUILD_CONTROL_REPO: ${BUILD_CONTROL_REPO}\n" +
         "BUILD_CONTROL_BRANCH: ${BUILD_CONTROL_BRANCH}\n" +
+        "BUILD_CONTROL_TAG: ${BUILD_CONTROL_TAG}\n" +
         "UTILS_REPO: ${UTILS_REPO}\n" +
         "  Trigger parameters:\n" +
         "this.cull_manifest: ${this.cull_manifest}\n" +

--- a/jenkins/generator_DSL.groovy
+++ b/jenkins/generator_DSL.groovy
@@ -13,8 +13,12 @@ this.script = "dispatch.groovy"
 
 this.build_control_repo = readFileFromWorkspace("VAR-build_control_repo")
 this.build_control_repo = this.build_control_repo.trim()
+
 this.build_control_branch = readFileFromWorkspace("VAR-build_control_branch")
 this.build_control_branch= this.build_control_branch.trim()
+
+this.build_control_tag = readFileFromWorkspace("VAR-build_control_tag")
+this.build_control_tag = this.build_control_tag.trim()
 
 // For each label (OS) in the list provided by the 'labels' job parameter, iterate
 // over each python version provided by the 'py_versions' job parameter, to obtain
@@ -30,7 +34,8 @@ for (label in labels.trim().tokenize()) {
         folder(suite_name) {
             description("Build suite generated: ${job_def_generation_time}\n" +
                         "build control repo: ${build_control_repo}\n" +
-                        "build control branch/tag: ${build_control_branch}\n" +
+                        "build control branch: ${build_control_branch}\n" +
+                        "build control tag: ${build_control_tag}\n" +
                         "conda version: ${conda_version}\n" +
                         "conda-build version: ${conda_build_version}\n" +
                         "utils_repo: ${utils_repo}")
@@ -55,6 +60,7 @@ for (label in labels.trim().tokenize()) {
             "PY_VERSION: ${py_version}\n" +
             "BUILD_CONTROL_REPO: ${build_control_repo}\n" +
             "BUILD_CONTROL_BRANCH: ${build_control_branch}\n" +
+            "BUILD_CONTROL_TAG: ${build_control_tag}\n" +
             "CONDA_VERSION: ${conda_version}\n" +
             "CONDA_BUILD_VERSION: ${conda_build_version}\n" +
             "CONDA_BASE_URL: ${conda_base_URL}\n" +
@@ -67,6 +73,7 @@ for (label in labels.trim().tokenize()) {
                 env("PY_VERSION", py_version)
                 env("BUILD_CONTROL_REPO", build_control_repo)
                 env("BUILD_CONTROL_BRANCH", build_control_branch)
+                env("BUILD_CONTROL_TAG", build_control_tag)
                 env("CONDA_VERSION", conda_version)
                 env("CONDA_BUILD_VERSION", conda_build_version)
                 env("CONDA_BASE_URL", conda_base_URL)
@@ -100,6 +107,9 @@ for (label in labels.trim().tokenize()) {
                     stringParam("build_control_branch",
                                 "build_control_branch-DEFAULTVALUE",
                                 "Branch checked out to obtain build system scripts.")
+                    stringParam("build_control_tag",
+                                "build_control_tag-DEFAULTVALUE",
+                                "Tag checked out to obtain build system scripts.")
                     stringParam("py_version",
                                 "py_version-DEFAULTVALUE",
                                 "python version to use")

--- a/jenkins/job-suite-generator.groovy
+++ b/jenkins/job-suite-generator.groovy
@@ -37,14 +37,18 @@ node("master") {
         // value to the jobDSL script.
 
         // Both 'scm.getUserRemoteConfigs' and 'getUrl' require script approval
-        build_control_repo= scm.getUserRemoteConfigs()[0].getUrl()
+        build_control_repo = scm.getUserRemoteConfigs()[0].getUrl()
         sh "echo ${build_control_repo} > VAR-build_control_repo"
 
         // Get branch spec component after last '/' character.
         // Branch names themselves shall not have slashes in them
         // when specified in the job-suite-generator job configuration.
         // This may also describe a tag, rather than a branch.
-        build_control_branch = scm.branches[0].toString().tokenize("/")[-1]
+        if (build_control_branch.find("tags") != null) {
+            build_control_branch = scm.branches[0].toString()
+        } else {
+            build_control_branch = scm.branches[0].toString().tokenize("/")[-1]
+        }
         sh "echo ${build_control_branch} > VAR-build_control_branch"
 
         // 'Parameters' variables are provided by the execution of the

--- a/jenkins/job-suite-generator.groovy
+++ b/jenkins/job-suite-generator.groovy
@@ -38,6 +38,7 @@ node("master") {
 
         // Both 'scm.getUserRemoteConfigs' and 'getUrl' require script approval
         build_control_repo = scm.getUserRemoteConfigs()[0].getUrl()
+        build_control_tag = ""
         sh "echo ${build_control_repo} > VAR-build_control_repo"
 
         // Get branch spec component after last '/' character.
@@ -45,11 +46,13 @@ node("master") {
         // when specified in the job-suite-generator job configuration.
         // This may also describe a tag, rather than a branch.
         if (build_control_branch.find("tags") != null) {
-            build_control_branch = scm.branches[0].toString()
-        } else {
+            build_control_branch = "master"
+            build_control_tag = build_control_branch.tokenize("/")
+        } else { // a branch, including */master
             build_control_branch = scm.branches[0].toString().tokenize("/")[-1]
         }
         sh "echo ${build_control_branch} > VAR-build_control_branch"
+        sh "echo ${build_control_tag} > VAR-build_control_tag"
 
         // 'Parameters' variables are provided by the execution of the
         // generator build task with parameters. Each is populated by a
@@ -61,12 +64,14 @@ node("master") {
         println("  From job config:\n" +
         "build_control_repo: ${build_control_repo}\n" +
         "build_control_branch: ${build_control_branch}\n" +
+        "build_control_tag: ${build_control_tag}\n" +
         "  Parameters:\n" +
         "manifest_file: ${this.manifest_file}\n" +
         "labels: ${this.labels}\n" +
         "py_versions: ${this.py_versions}\n" +
         "conda_version: ${this.conda_version}\n" +
         "conda_build_version: ${this.conda_build_version}\n" +
+        "conda_build_tag: ${this.conda_build_tag}\n" +
         "conda_base_URL: ${this.conda_base_URL}\n" +
         "utils_repo: ${this.utils_repo}\n" +
         "old_jobs_action: ${this.old_jobs_action}\n" +

--- a/jenkins/job-suite-generator.groovy
+++ b/jenkins/job-suite-generator.groovy
@@ -40,16 +40,17 @@ node("master") {
         build_control_repo = scm.getUserRemoteConfigs()[0].getUrl()
         build_control_tag = ""
         sh "echo ${build_control_repo} > VAR-build_control_repo"
+        build_control_bt_spec = scm.branches[0].toString()
 
         // Get branch spec component after last '/' character.
         // Branch names themselves shall not have slashes in them
         // when specified in the job-suite-generator job configuration.
         // This may also describe a tag, rather than a branch.
-        if (build_control_branch.find("tags") != null) {
+        if (build_control_bt_spec.find("tags") != null) {
             build_control_branch = "master"
-            build_control_tag = build_control_branch.tokenize("/")
+            build_control_tag = build_control_bt_spec.tokenize("/")[-1]
         } else { // a branch, including */master
-            build_control_branch = scm.branches[0].toString().tokenize("/")[-1]
+            build_control_branch = build_control_bt_spec.tokenize("/")[-1]
         }
         sh "echo ${build_control_branch} > VAR-build_control_branch"
         sh "echo ${build_control_tag} > VAR-build_control_tag"

--- a/jenkins/job-suite-generator.groovy
+++ b/jenkins/job-suite-generator.groovy
@@ -46,6 +46,8 @@ node("master") {
         // Branch names themselves shall not have slashes in them
         // when specified in the job-suite-generator job configuration.
         // This may also describe a tag, rather than a branch.
+        // Requires in-process script approval for:
+        //   java.lang.String java.lang.String (.find method)
         if (build_control_bt_spec.find("tags") != null) {
             build_control_branch = "master"
             build_control_tag = build_control_bt_spec.tokenize("/")[-1]
@@ -72,7 +74,6 @@ node("master") {
         "py_versions: ${this.py_versions}\n" +
         "conda_version: ${this.conda_version}\n" +
         "conda_build_version: ${this.conda_build_version}\n" +
-        "conda_build_tag: ${this.conda_build_tag}\n" +
         "conda_base_URL: ${this.conda_base_URL}\n" +
         "utils_repo: ${this.utils_repo}\n" +
         "old_jobs_action: ${this.old_jobs_action}\n" +

--- a/jenkins/package_builder.groovy
+++ b/jenkins/package_builder.groovy
@@ -25,6 +25,7 @@ node(this.label) {
         "env.JENKINS_HOME: ${env.JENKINS_HOME}\n" +
         "parameter build_control_repo: ${this.build_control_repo}\n" +
         "parameter build_control_branch: ${this.build_control_branch}\n" +
+        "parameter build_control_tag: ${this.build_control_tag}\n" +
         "parameter parent_workspace: ${this.parent_workspace}\n" +
         "parameter py_version: ${this.py_version}\n" +
         "parameter numpy_version: ${this.numpy_version}\n" +


### PR DESCRIPTION
Correct shortcoming in how Jenkins job configuration SCM branch/tag specification gets propagated to generated jobs.