### PR TITLE
Numpy 'matrix build' support; channel access in test stage

### DIFF
--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -239,8 +239,6 @@ node(LABEL) {
                  string(name: "build_control_repo", value: BUILD_CONTROL_REPO),
                  string(name: "build_control_branch", value: BUILD_CONTROL_BRANCH),
                  string(name: "py_version", value: PY_VERSION),
-                 //string(name: "numpy_version",
-                 //       value: "${this.manifest.numpy_version}"),
                  string(name: "numpy_version", value: NUMPY_VERSION),
                  string(name: "parent_workspace", value: env.WORKSPACE),
                  string(name: "cull_manifest", value: this.cull_manifest),

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -101,6 +101,7 @@ node(LABEL) {
         "LABEL: ${LABEL}\n" +
         "env.NODE_NAME: ${env.NODE_NAME}\n" +
         "PY_VERSION: ${PY_VERSION}\n" +
+        "NUMPY_VERSION: ${NUMPY_VERSION}\n" +
         "MANIFEST_FILE: ${MANIFEST_FILE}\n" +
         "CONDA_VERSION: ${CONDA_VERSION}\n" +
         "CONDA_BUILD_VERSION: ${CONDA_BUILD_VERSION}\n" +
@@ -237,8 +238,9 @@ node(LABEL) {
                  string(name: "build_control_repo", value: BUILD_CONTROL_REPO),
                  string(name: "build_control_branch", value: BUILD_CONTROL_BRANCH),
                  string(name: "py_version", value: PY_VERSION),
-                 string(name: "numpy_version",
-                        value: "${this.manifest.numpy_version}"),
+                 //string(name: "numpy_version",
+                 //       value: "${this.manifest.numpy_version}"),
+                 string(name: "numpy_version", value: NUMPY_VERSION),
                  string(name: "parent_workspace", value: env.WORKSPACE),
                  string(name: "cull_manifest", value: this.cull_manifest),
                  string(name: "channel_URL", value: this.manifest.channel_URL)],

--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -212,6 +212,7 @@ node(LABEL) {
         cmd = "rambo"
         args = ["--platform ${this.CONDA_PLATFORM}",
                 "--python ${PY_VERSION}",
+                "--numpy ${NUMPY_VERSION}",
                 "--manifest manifests/${MANIFEST_FILE}",
                 "--file ${build_list_file}",
                 "${culled_option}",

--- a/jenkins/generator_DSL.groovy
+++ b/jenkins/generator_DSL.groovy
@@ -39,7 +39,8 @@ for (label in labels.trim().tokenize()) {
                             "build control tag: ${build_control_tag}\n" +
                             "conda version: ${conda_version}\n" +
                             "conda-build version: ${conda_build_version}\n" +
-                            "utils_repo: ${utils_repo}")
+                            "utils_repo: ${utils_repo}\n" +
+                            "publication_root: ${config.publication_root}")
             }
 
             //-----------------------------------------------------------------------

--- a/jenkins/generator_DSL.groovy
+++ b/jenkins/generator_DSL.groovy
@@ -26,118 +26,122 @@ this.build_control_tag = this.build_control_tag.trim()
 // each combination.
 for (label in labels.trim().tokenize()) {
     for (py_version in py_versions.trim().tokenize()) {
+        for (numpy_version in numpy_versions.trim().tokenize()) {
 
-        //-----------------------------------------------------------------------
-        // Create a folder to contain the jobs which are created below.
+            //-----------------------------------------------------------------------
+            // Create a folder to contain the jobs which are created below.
 
-        suite_name = "${manifest_file.tokenize(".")[0]}_${label}_py${py_version}"
-        folder(suite_name) {
-            description("Build suite generated: ${job_def_generation_time}\n" +
-                        "build control repo: ${build_control_repo}\n" +
-                        "build control branch: ${build_control_branch}\n" +
-                        "build control tag: ${build_control_tag}\n" +
-                        "conda version: ${conda_version}\n" +
-                        "conda-build version: ${conda_build_version}\n" +
-                        "utils_repo: ${utils_repo}")
-        }
-
-        //-----------------------------------------------------------------------
-        // Generate the dispatch job that will trigger the chain of package
-        // build jobs.
-        pipelineJob("${suite_name}/_${script.tokenize(".")[0]}") {
-            // At trigger-time, allow for setting manifest culling behavior.
-            parameters {
-                booleanParam("cull_manifest",
-                             true,
-                             "Whether or not package recipes that would generate a " +
-                             "package file name that already exists in the manfest's" +
-                             " channel archive are removed from the build list.")
+            suite_name = "${manifest_file.tokenize(".")[0]}_${label}_py${py_version}_np${numpy_version}"
+            folder(suite_name) {
+                description("Build suite generated: ${job_def_generation_time}\n" +
+                            "build control repo: ${build_control_repo}\n" +
+                            "build control branch: ${build_control_branch}\n" +
+                            "build control tag: ${build_control_tag}\n" +
+                            "conda version: ${conda_version}\n" +
+                            "conda-build version: ${conda_build_version}\n" +
+                            "utils_repo: ${utils_repo}")
             }
-            println("\n" +
-            "script: ${this.script}\n" +
-            "MANIFEST_FILE: ${manifest_file}\n" +
-            "LABEL: ${label}\n" +
-            "PY_VERSION: ${py_version}\n" +
-            "BUILD_CONTROL_REPO: ${build_control_repo}\n" +
-            "BUILD_CONTROL_BRANCH: ${build_control_branch}\n" +
-            "BUILD_CONTROL_TAG: ${build_control_tag}\n" +
-            "CONDA_VERSION: ${conda_version}\n" +
-            "CONDA_BUILD_VERSION: ${conda_build_version}\n" +
-            "CONDA_BASE_URL: ${conda_base_URL}\n" +
-            "UTILS_REPO: ${utils_repo}\n")
-            environmentVariables {
-                env("JOB_DEF_GENERATION_TIME", job_def_generation_time)
-                env("SCRIPT", this.script)
-                env("MANIFEST_FILE", manifest_file)
-                env("LABEL", label)
-                env("PY_VERSION", py_version)
-                env("BUILD_CONTROL_REPO", build_control_repo)
-                env("BUILD_CONTROL_BRANCH", build_control_branch)
-                env("BUILD_CONTROL_TAG", build_control_tag)
-                env("CONDA_VERSION", conda_version)
-                env("CONDA_BUILD_VERSION", conda_build_version)
-                env("CONDA_BASE_URL", conda_base_URL)
-                env("UTILS_REPO", utils_repo)
-            }
-            definition {
-                cps {
-                    script(readFileFromWorkspace("jenkins/${this.script}"))
-                    sandbox()
+
+            //-----------------------------------------------------------------------
+            // Generate the dispatch job that will trigger the chain of package
+            // build jobs.
+            pipelineJob("${suite_name}/_${script.tokenize(".")[0]}") {
+                // At trigger-time, allow for setting manifest culling behavior.
+                parameters {
+                    booleanParam("cull_manifest",
+                                 true,
+                                 "Whether or not package recipes that would generate a " +
+                                 "package file name that already exists in the manfest's" +
+                                 " channel archive are removed from the build list.")
                 }
-            }
-        }
-
-
-        //-----------------------------------------------------------------------
-        // Generate the series of actual package building jobs.
-
-        for(pkg in config.packages) {
-
-            pipelineJob("${suite_name}/${pkg}") {
+                println("\n" +
+                "script: ${this.script}\n" +
+                "MANIFEST_FILE: ${manifest_file}\n" +
+                "LABEL: ${label}\n" +
+                "PY_VERSION: ${py_version}\n" +
+                "NUMPY_VERSION: ${numpy_version}\n" +
+                "BUILD_CONTROL_REPO: ${build_control_repo}\n" +
+                "BUILD_CONTROL_BRANCH: ${build_control_branch}\n" +
+                "BUILD_CONTROL_TAG: ${build_control_tag}\n" +
+                "CONDA_VERSION: ${conda_version}\n" +
+                "CONDA_BUILD_VERSION: ${conda_build_version}\n" +
+                "CONDA_BASE_URL: ${conda_base_URL}\n" +
+                "UTILS_REPO: ${utils_repo}\n")
                 environmentVariables {
                     env("JOB_DEF_GENERATION_TIME", job_def_generation_time)
-                }
-                parameters {
-                    stringParam("label",
-                                "label-DEFAULTVALUE",
-                                "The node on which to run.")
-                    stringParam("build_control_repo",
-                                "build_control_repo-DEFAULTVALUE",
-                                "Repository containing the build system scripts.")
-                    stringParam("build_control_branch",
-                                "build_control_branch-DEFAULTVALUE",
-                                "Branch checked out to obtain build system scripts.")
-                    stringParam("build_control_tag",
-                                "build_control_tag-DEFAULTVALUE",
-                                "Tag checked out to obtain build system scripts.")
-                    stringParam("py_version",
-                                "py_version-DEFAULTVALUE",
-                                "python version to use")
-                    stringParam("numpy_version",
-                                "numpy_version-DEFAULTVALUE",
-                                "Version of numpy to use")
-                    stringParam("parent_workspace",
-                                "parent_workspace-DEFAULTVALUE",
-                                "The workspace dir of the dispatch job")
-                    stringParam("manifest_file",
-                                "manifest_file-DEFAULTVALUE",
-                                "Manifest (release) file to use for the build.")
-                    stringParam("cull_manifest",
-                                "cull_manifest-DEFAULTVALUE",
-                                "Was the manifest culled as part of dispatch?")
-                    stringParam("channel_URL",
-                                "channel_URL-DEFAULTVALUE",
-                                "Publication channel used for culled builds.")
+                    env("SCRIPT", this.script)
+                    env("MANIFEST_FILE", manifest_file)
+                    env("LABEL", label)
+                    env("PY_VERSION", py_version)
+                    env("NUMPY_VERSION", numpy_version)
+                    env("BUILD_CONTROL_REPO", build_control_repo)
+                    env("BUILD_CONTROL_BRANCH", build_control_branch)
+                    env("BUILD_CONTROL_TAG", build_control_tag)
+                    env("CONDA_VERSION", conda_version)
+                    env("CONDA_BUILD_VERSION", conda_build_version)
+                    env("CONDA_BASE_URL", conda_base_URL)
+                    env("UTILS_REPO", utils_repo)
                 }
                 definition {
                     cps {
-                        script(readFileFromWorkspace("jenkins/package_builder.groovy"))
+                        script(readFileFromWorkspace("jenkins/${this.script}"))
                         sandbox()
                     }
                 }
-            } // end pipelineJob
+            }
 
-        } //end for(pkg...
 
+            //-----------------------------------------------------------------------
+            // Generate the series of actual package building jobs.
+
+            for(pkg in config.packages) {
+
+                pipelineJob("${suite_name}/${pkg}") {
+                    environmentVariables {
+                        env("JOB_DEF_GENERATION_TIME", job_def_generation_time)
+                    }
+                    parameters {
+                        stringParam("label",
+                                    "label-DEFAULTVALUE",
+                                    "The node on which to run.")
+                        stringParam("build_control_repo",
+                                    "build_control_repo-DEFAULTVALUE",
+                                    "Repository containing the build system scripts.")
+                        stringParam("build_control_branch",
+                                    "build_control_branch-DEFAULTVALUE",
+                                    "Branch checked out to obtain build system scripts.")
+                        stringParam("build_control_tag",
+                                    "build_control_tag-DEFAULTVALUE",
+                                    "Tag checked out to obtain build system scripts.")
+                        stringParam("py_version",
+                                    "py_version-DEFAULTVALUE",
+                                    "python version to use")
+                        stringParam("numpy_version",
+                                    "numpy_version-DEFAULTVALUE",
+                                    "Version of numpy to use")
+                        stringParam("parent_workspace",
+                                    "parent_workspace-DEFAULTVALUE",
+                                    "The workspace dir of the dispatch job")
+                        stringParam("manifest_file",
+                                    "manifest_file-DEFAULTVALUE",
+                                    "Manifest (release) file to use for the build.")
+                        stringParam("cull_manifest",
+                                    "cull_manifest-DEFAULTVALUE",
+                                    "Was the manifest culled as part of dispatch?")
+                        stringParam("channel_URL",
+                                    "channel_URL-DEFAULTVALUE",
+                                    "Publication channel used for culled builds.")
+                    }
+                    definition {
+                        cps {
+                            script(readFileFromWorkspace("jenkins/package_builder.groovy"))
+                            sandbox()
+                        }
+                    }
+                } // end pipelineJob
+
+            } //end for(pkg...
+
+        } //end for(numpy_version
     } // end for(py_version
 } // end for(label

--- a/jenkins/job-suite-generator.groovy
+++ b/jenkins/job-suite-generator.groovy
@@ -72,6 +72,7 @@ node("master") {
         "manifest_file: ${this.manifest_file}\n" +
         "labels: ${this.labels}\n" +
         "py_versions: ${this.py_versions}\n" +
+        "numpy_versions: ${this.numpy_versions}\n" +
         "conda_version: ${this.conda_version}\n" +
         "conda_build_version: ${this.conda_build_version}\n" +
         "conda_base_URL: ${this.conda_base_URL}\n" +

--- a/jenkins/package_builder.groovy
+++ b/jenkins/package_builder.groovy
@@ -45,13 +45,14 @@ node(this.label) {
 
             cmd = "conda build"
 
+            // Use channel URL obtained from manifest in build command if
+            // manifest has been culled to allow packages being built to
+            // simply download dependency packages from the publication
+            // channel as needed, rather than build them as part of the
+            // package build session that requires them.
+            def channel_option = "--channel ${this.channel_URL}"
+
             stage("Build") {
-                // Use channel URL obtained from manifest in build command if
-                // manifest has been culled to allow packages being built to
-                // simply download dependency packages from the publication
-                // channel as needed, rather than build them as part of the
-                // package build session that requires them.
-                def channel_option = "--channel ${this.channel_URL}"
                 if (this.cull_manifest == "false") {
                     channel_option = ""
                 }
@@ -87,7 +88,10 @@ node(this.label) {
                     build_cmd = cmd
                     args = ["--test",
                             "--python=${this.py_version}",
-                            "--numpy=${this.numpy_version}"]
+                            "--numpy=${this.numpy_version}",
+                            "--override-channels",
+                            "--channel defaults",
+                            "${channel_option}"]
                     for (arg in args) {
                         build_cmd = "${build_cmd} ${arg}"
                     }

--- a/manifests/dev-test.yaml
+++ b/manifests/dev-test.yaml
@@ -5,8 +5,7 @@ repository: 'https://github.com/astroconda/astroconda-dev'
 channel_URL: 'http://ssb.stsci.edu/astroconda-dev'
 
 # publication_root path needs to be visible from the slave nodes.
-publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-dev-staging'
-numpy_version: 1.13
+publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-dev-testing'
 packages:
   - fitsverify
 #  - crds

--- a/manifests/dev.yaml
+++ b/manifests/dev.yaml
@@ -6,7 +6,6 @@ channel_URL: 'http://ssb.stsci.edu/astroconda-dev'
 
 # publication_root path needs to be visible from the slave nodes.
 publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-dev-staging'
-numpy_version: 1.13
 packages:
   - stsci.tools
   - stsci.imagestats

--- a/manifests/public.yaml
+++ b/manifests/public.yaml
@@ -6,7 +6,6 @@ channel_URL: 'http://ssb.stsci.edu/astroconda'
 
 # publication_root path needs to be visible from the slave nodes.
 publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-pub-staging'
-numpy_version: 1.13
 packages:
   - stsci.tools
   - stsci.imagestats

--- a/manifests/test-fail.yaml
+++ b/manifests/test-fail.yaml
@@ -5,8 +5,7 @@ repository: 'https://github.com/astroconda/astroconda-contrib'
 channel_URL: 'http://ssb.stsci.edu/astroconda'
 
 # publication_root path needs to be visible from the slave nodes.
-publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-pub-staging'
-numpy_version: 1.11
+publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-pub-testing'
 packages:
   - verhawk
   - INTENTIONALLY_INVALID

--- a/manifests/test.yaml
+++ b/manifests/test.yaml
@@ -1,12 +1,11 @@
 # Recipe repository
-repository: 'https://github.com/astroconda/astroconda-dev'
+repository: 'https://github.com/astroconda/astroconda-contrib'
 
 # Publication channel to consult when determining what packages already exist.
-channel_URL: 'http://ssb.stsci.edu/astroconda-dev'
+channel_URL: 'http://ssb.stsci.edu/astroconda'
 
 # publication_root path needs to be visible from the slave nodes.
-publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-dev-staging'
-numpy_version: 1.13
+publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-pub-testing'
 packages:
   - costools
   - cfitsio


### PR DESCRIPTION
* Iterate over numpy versions specified for each existing LABEL/py_version combination when generating job suites.
* Remove numpy version specification from manifest files
* Pass numpy version to rambo for build sequence calculation
 also in this PR
* Added defaults and manifest-specified channel access for pulling in necessary packages during the test stage.