### PR TITLE
generalized conda-build 3.x substring bugfix patch

### DIFF
--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -200,6 +200,15 @@ node(LABEL) {
             def full_patchname = "${patches_dir}/${patchname}"
             sh "patch ${filename} ${full_patchname}"
         }
+        if (conda_build_maj_ver == "3") {
+            println("conda-build major version ${conda_build_maj_ver} detected. Applying bugfix patch.")
+            def filename = "${this.conda_install_dir}/lib/python${PY_VERSION}/" +
+                           "site-packages/conda_build/config.py"
+            def patches_dir = "${env.WORKSPACE}/patches"
+            def patchname = "conda_build_3.0.15_substr_fix2.patch"
+            def full_patchname = "${patches_dir}/${patchname}"
+            sh "patch ${filename} ${full_patchname}"
+        }
 
         // (conda-build 3.x only)
         // Create and populate environment to be used for pinning reference when

--- a/manifests/dev-test.yaml
+++ b/manifests/dev-test.yaml
@@ -5,9 +5,11 @@ repository: 'https://github.com/astroconda/astroconda-dev'
 channel_URL: 'http://ssb.stsci.edu/astroconda-dev'
 
 # publication_root path needs to be visible from the slave nodes.
-publication_root: '/eng/ssb/websites/ssbpublic/astroconda-j-dev-testing'
+publication_root: '/eng/ssb/websites/ssbpublic/astroconda-dev'
 packages:
-  - drizzlepac
+#  - drizzlepac 
+  - jwst_gtvt
+  - jwst
 #  - crds
 #  - cube-tools
 #  - sphinxcontrib-programoutput

--- a/patches/conda_build_3.0.15_substr_fix2.patch
+++ b/patches/conda_build_3.0.15_substr_fix2.patch
@@ -1,0 +1,11 @@
+--- config.py	2017-09-18 17:22:59.000000000 -0400
++++ config.py.new	2017-09-18 16:39:48.000000000 -0400
+@@ -370,7 +370,7 @@
+                                                      "to preserve croot during path joins")
+             build_folders = sorted([os.path.basename(build_folder)
+                             for build_folder in get_build_folders(self.croot)
+-                            if os.path.basename(build_folder).startswith(package_name + "_")])
++                            if build_folder[:build_folder.rfind('_')] == package_name])
+             if self.dirty and build_folders:
+                 # Use the most recent build with matching recipe name
+                 self._build_id = build_folders[-1]


### PR DESCRIPTION
* Generalized bugfix for the issue first noticed in conda-build 2.x that incorrectly selects pre-existing build directories whose names contain other package names as a substring. Packages with underscore(s) in their name and also another package name as a substring exercised this bug again, so a (hopefully this time) more reliable matching expression was used in the correction to conda-build.
* Updated testing manifest.
* Added tested patch file which applies to both installed versions of conda-build under py2.x and py3.x for conda-build 3.x.
   * This PR only applies to conda-build 3.x (another may be created if conda-build 2.x behavior needs to be fixed as well).