### PR TITLE
Add ability to filter non-python packages from a platform's build.

### DIFF
--- a/jenkins/dispatch.groovy
+++ b/jenkins/dispatch.groovy
@@ -275,19 +275,20 @@ node(LABEL) {
     stage("Generate build list") {
         // Generate a filtered, optionally culled, & dependency-ordered list
         // of available package recipes.
-        def culled_option = ""
-        if (this.cull_manifest == "true") {
-            culled_option = "--culled"
-        }
         def build_list_file = "build_list"
         cmd = "rambo"
         args = ["--platform ${this.CONDA_PLATFORM}",
                 "--python ${PY_VERSION}",
                 "--numpy ${NUMPY_VERSION}",
                 "--manifest manifests/${MANIFEST_FILE}",
-                "--file ${build_list_file}",
-                "${culled_option}",
-                this.recipes_dir]
+                "--file ${build_list_file}"]
+        if (this.cull_manifest == "true") {
+            args.add("--culled")
+        }
+        if (this.filter_nonpython == "true") {
+           args.add("--filter-nonpy")
+        }
+        args.add(this.recipes_dir)
         for (arg in args) {
             cmd = "${cmd} ${arg}"
         }

--- a/jenkins/generator_DSL.groovy
+++ b/jenkins/generator_DSL.groovy
@@ -71,6 +71,11 @@ for (label in labels) {
                                  "Whether or not package recipes that would generate a " +
                                  "package file name that already exists in the manfest's" +
                                  " channel archive are removed from the build list.")
+                    booleanParam("filter_nonpython",
+                                 false,
+                                 "Whether or not package without a python dependency are" +
+                                 " skipped as they only need to be built on a single" +
+                                 " platform.")
                     textParam("supp_env_vars",
                               "",
                               "List of supplemental environment variables to define " +


### PR DESCRIPTION
* Generate dispatch jobs with appropriate filtering parameter flag.
* Select a master platform for each OS at trigger time, selectively
passing the filter flag as appropriate.