### PR TITLE
Allow override of master_platforms for building non-python packages.

### DIFF
--- a/jenkins/generator_DSL.groovy
+++ b/jenkins/generator_DSL.groovy
@@ -216,6 +216,12 @@ pipelineJob("trigger_${manifest_basename}") {
                   "",
                   "List of supplemental environment variables to define in " +
                   "the build envioronment.")
+        textParam("non_python_pkg_platform",
+                  "py3.6",
+                  "Only platforms with this python version in their name will " + 
+                  "be used to host the building of non-python packages. This " +
+                  "prevents non-python packages from being built multiple " +
+                  "times unnecessarily.")
         textParam("mail_recipients",
                   this.mail_recipients,
                   "Whom to pester.")

--- a/jenkins/multi_trigger.groovy
+++ b/jenkins/multi_trigger.groovy
@@ -18,17 +18,39 @@ node('master') {
                 os_list.add(os)
             }
         }
-        // Compose list of master platforms
-        def master_platforms = []
-        for (osval in os_list) {
-            for (platform in platforms) {
-                if (platform.contains(osval)) {
-                    master_platforms.add(platform)
-                    break
-                }
+
+        // Determine if the master platform has been overridden
+        // by the specification of a valid platform name substring.
+        def override_master_platform = false
+        for (platform in platforms) {
+            if (platform.contains(non_python_pkg_platform)) {
+                override_master_platform = true
+                break
             }
         }
-        println("master_platforms: ${master_platforms}")
+
+        def master_platforms = []
+        if (override_master_platform) {
+            for (platform in platforms) {
+                if (platform.contains(non_python_pkg_platform)) {
+                    master_platforms.add(platform)
+                }
+            }
+            println("Automatic master_platforms overridden by job parameter." +
+                    " Building non-python packages only on master_platforms: ${master_platforms}")
+        } else {
+            // Compose automatic list of master platforms.
+            for (osval in os_list) {
+                for (platform in platforms) {
+                    if (platform.contains(osval)) {
+                        master_platforms.add(platform)
+                        break
+                    }
+                }
+            }
+            println("Building non-python packages only on master_platforms: ${master_platforms}")
+        }
+
 
         for (platform in platforms) {
             build_type = platform.tokenize("_")[0]
@@ -48,6 +70,7 @@ node('master') {
             if (master_platforms.contains(platname)) {
                 filter_nonpython = false
             }
+
             tasks["${platname}"] = {
                 build_objs["${platname}"] = build(
                     job: "/AstroConda/${platname}/_dispatch",


### PR DESCRIPTION
Previously, for non-python packages a master platform was defined for each OS as the platform name with the 'latest' lexicographic search order. (See https://github.com/rendinam/build_control/blob/22f7f27bc736cd9f5defa181b555348b99df936a/jenkins/multi_trigger.groovy#L60) This ended up becoming the platforms supporting python 3.7 once that python version was added. This unfortunately prevents the `waf` configuration tool in the `hstcal` project from working as it is not yet supported under that python version, and thus `hstcal` would not build at all, since it was only assigned to those py3.7 master platforms. The change here allows for build jobs in Jenkins to override the master platforms used for non-python package building purposes with a text parameter, set by default to `py3.6`.